### PR TITLE
Fix CI and add support for aarch64-apple-darwin

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,14 @@ jobs:
         with:
           command: build
           args: --release --target ${{ matrix.target }} --target-dir output/
-      - run: cp */**/$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].targets[] | select( .kind | map(. == "bin") | any ) | .name') $(echo ${{ matrix.name }})
+      - run: |
+          PROJ=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].targets[] | select( .kind | map(. == "bin") | any )
+          FILEPATH=target/${{ matrix.target }}/release/$PROJ | .name')
+          if [[ -f $FILEPATH ]]; then
+            cp $FILEPATH $(echo ${{ matrix.name }})
+          else
+            cp target/release/$PROJ $(echo ${{ matrix.name }})
+          fi
       - uses: ncipollo/release-action@v1
         with:
           allowUpdates: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           command: build
           args: --release --target ${{ matrix.target }} --target-dir output/
-      - run: bash -c "mkdir -p target/${{ matrix.target }}/debug && cp target/{,${{ matrix.target }}/}debug/calcagebra 2>/dev/null; cp target/${{ matrix.target }}/release/calcagebra $(echo ${{ matrix.name }})"
+      - run: bash -c "mkdir -p target/${{ matrix.target }}/release && cp target/{,${{ matrix.target }}/}release/calcagebra || true; cp target/${{ matrix.target }}/release/calcagebra $(echo ${{ matrix.name }})"
       - uses: ncipollo/release-action@v1
         with:
           allowUpdates: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - target: x86_64-pc-windows-gnu
+          - target: x86_64-pc-windows-msvc
             name: calcagebra.exe
             os: windows-latest
           - target: x86_64-unknown-linux-musl
@@ -44,8 +44,8 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --target ${{ matrix.target }}
-      - run: cp target/${{ matrix.target }}/release/$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].targets[] | select( .kind | map(. == "bin") | any ) | .name') $(echo ${{ matrix.name }})
+          args: --release --target ${{ matrix.target }} --target-dir output/
+      - run: mkdir -p target/${{ matrix.target }}/debug && cp target/{,${{ matrix.target }}/}debug/calcagebra 2>/dev/null; cp target/${{ matrix.target }}/release/$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].targets[] | select( .kind | map(. == "bin") | any ) | .name') $(echo ${{ matrix.name }})
       - uses: ncipollo/release-action@v1
         with:
           allowUpdates: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,7 @@ jobs:
           command: build
           args: --release --target ${{ matrix.target }} --target-dir output/
       - run: |
-          PROJ=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].targets[] | select( .kind | map(. == "bin") | any )
+          PROJ=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].targets[] | select( .kind | map(. == "bin") | any')
           FILEPATH=target/${{ matrix.target }}/release/$PROJ | .name')
           if [[ -f $FILEPATH ]]; then
             cp $FILEPATH $(echo ${{ matrix.name }})

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,8 +48,8 @@ jobs:
       - run: |
           PROJ=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].targets[] | select( .kind | map(. == "bin") | any ) | .name')
           FILEPATH=target/${{ matrix.target }}/release/$PROJ
-          if [[ -f $FILEPATH ]]; then
-            cp $FILEPATH $(echo ${{ matrix.name }})
+          if [[ cp $FILEPATH $(echo ${{ matrix.name }}) ]]; then
+            
           else
             cp target/release/$PROJ $(echo ${{ matrix.name }})
           fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           command: build
           args: --release --target ${{ matrix.target }} --target-dir output/
-      - run: bash -c "mkdir -p target/${{ matrix.target }}/debug && cp target/{,${{ matrix.target }}/}debug/calcagebra 2>/dev/null; cp target/${{ matrix.target }}/release/$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].targets[] | select( .kind | map(. == 'bin') | any ) | .name') $(echo ${{ matrix.name }})"
+      - run: bash -c "mkdir -p target/${{ matrix.target }}/debug && cp target/{,${{ matrix.target }}/}debug/calcagebra 2>/dev/null; cp target/${{ matrix.target }}/release/calcagebra $(echo ${{ matrix.name }})"
       - uses: ncipollo/release-action@v1
         with:
           allowUpdates: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,17 +6,23 @@ on:
 jobs:
   release:
     name: release ${{ matrix.target }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - target: x86_64-pc-windows-gnu
             name: calcagebra.exe
+            os: windows-latest
           - target: x86_64-unknown-linux-musl
             name: calcagebra
+            os: ubuntu-latest
           - target: x86_64-apple-darwin
             name: calcagebra-darwin
+            os: macos-latest
+          - target: aarch64-apple-darwin
+            name: calcagebra-aarch64-darwin
+            os: macos-latest
     steps:
       - uses: actions/checkout@master
       - uses: actions-rs/toolchain@v1
@@ -37,7 +43,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release
+          args: --release --target ${{ matrix.target }}
       - run: cp target/release/$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].targets[] | select( .kind | map(. == "bin") | any ) | .name') $(echo ${{ matrix.name }})
       - uses: ncipollo/release-action@v1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           command: build
           args: --release --target ${{ matrix.target }} --target-dir output/
-      - run: mkdir -p target/${{ matrix.target }}/debug && cp target/{,${{ matrix.target }}/}debug/calcagebra 2>/dev/null; cp target/${{ matrix.target }}/release/$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].targets[] | select( .kind | map(. == "bin") | any ) | .name') $(echo ${{ matrix.name }})
+      - run: bash -c "mkdir -p target/${{ matrix.target }}/debug && cp target/{,${{ matrix.target }}/}debug/calcagebra 2>/dev/null; cp target/${{ matrix.target }}/release/$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].targets[] | select( .kind | map(. == 'bin') | any ) | .name') $(echo ${{ matrix.name }})"
       - uses: ncipollo/release-action@v1
         with:
           allowUpdates: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,7 @@
 on:
-  # - push:
-  #   tags:
-  #   - '*'
-  workflow_dispatch
+  push:
+    tags:
+    - '*'
 
 jobs:
   release:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,8 @@
 on:
-  push:
-    tags:
-    - '*'
+  # - push:
+  #   tags:
+  #   - '*'
+  workflow_dispatch
 
 jobs:
   release:
@@ -44,12 +45,12 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --target ${{ matrix.target }} --target-dir output/
+          args: --release --target ${{ matrix.target }}
       - run: |
           PROJ=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].targets[] | select( .kind | map(. == "bin") | any ) | .name')
           FILEPATH=target/${{ matrix.target }}/release/$PROJ
-          if [[ cp $FILEPATH $(echo ${{ matrix.name }}) ]]; then
-            
+          if [[ -f $FILEPATH ]]; then
+            cp $FILEPATH $(echo ${{ matrix.name }})
           else
             cp target/release/$PROJ $(echo ${{ matrix.name }})
           fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           command: build
           args: --release --target ${{ matrix.target }}
+      - shell: bash
       - run: |
           PROJ=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].targets[] | select( .kind | map(. == "bin") | any ) | .name')
           FILEPATH=target/${{ matrix.target }}/release/$PROJ

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,7 @@ jobs:
           command: build
           args: --release --target ${{ matrix.target }}
       - shell: bash
-      - run: |
+        run: |
           PROJ=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].targets[] | select( .kind | map(. == "bin") | any ) | .name')
           FILEPATH=target/${{ matrix.target }}/release/$PROJ
           if [[ -f $FILEPATH ]]; then

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,7 @@ jobs:
           command: build
           args: --release --target ${{ matrix.target }} --target-dir output/
       - run: |
-          PROJ=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].targets[] | select( .kind | map(. == "bin") | any')
+          PROJ=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].targets[] | select( .kind | map(. == "bin") | any ) | .name')
           FILEPATH=target/${{ matrix.target }}/release/$PROJ | .name')
           if [[ -f $FILEPATH ]]; then
             cp $FILEPATH $(echo ${{ matrix.name }})

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,7 @@ jobs:
           args: --release --target ${{ matrix.target }} --target-dir output/
       - run: |
           PROJ=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].targets[] | select( .kind | map(. == "bin") | any ) | .name')
-          FILEPATH=target/${{ matrix.target }}/release/$PROJ | .name')
+          FILEPATH=target/${{ matrix.target }}/release/$PROJ
           if [[ -f $FILEPATH ]]; then
             cp $FILEPATH $(echo ${{ matrix.name }})
           else

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           command: build
           args: --release --target ${{ matrix.target }} --target-dir output/
-      - run: bash -c "mkdir -p target/${{ matrix.target }}/release && cp target/{,${{ matrix.target }}/}release/calcagebra || true; cp target/${{ matrix.target }}/release/calcagebra $(echo ${{ matrix.name }})"
+      - run: cp */**/$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].targets[] | select( .kind | map(. == "bin") | any ) | .name') $(echo ${{ matrix.name }})
       - uses: ncipollo/release-action@v1
         with:
           allowUpdates: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
             toolchain: stable
+            target: ${{ matrix.target }}
             default: true
             override: true
             components: rustfmt, clippy

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           command: build
           args: --release --target ${{ matrix.target }}
-      - run: cp target/release/$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].targets[] | select( .kind | map(. == "bin") | any ) | .name') $(echo ${{ matrix.name }})
+      - run: cp target/${{ matrix.target }}/release/$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].targets[] | select( .kind | map(. == "bin") | any ) | .name') $(echo ${{ matrix.name }})
       - uses: ncipollo/release-action@v1
         with:
           allowUpdates: true


### PR DESCRIPTION
This PR adds support for aarch64-apple-darwin architecture so that work on an installer may begin. It also fixes an issue with the previous CI config where the workflow would creat 3 identical binaries that were only different in name. As seen here each file has the exact same hash despite supposedly being built for their respective architectures.
<img width="479" alt="Screenshot of a terminal showing three files with identical md5 hashes" src="https://github.com/megatank58/calcagebra/assets/83902606/55136047-a7c7-4f0c-b51e-90b6ad4bf62b">
